### PR TITLE
Preserve user clipboard during dictation paste

### DIFF
--- a/BetterVoice/BetterVoice/Services/System/PasteService.swift
+++ b/BetterVoice/BetterVoice/Services/System/PasteService.swift
@@ -41,8 +41,12 @@ final class PasteService: PasteServiceProtocol {
             throw PasteServiceError.emptyText
         }
 
-        // Copy text to clipboard
         let pasteboard = NSPasteboard.general
+
+        // Save current clipboard contents
+        let savedClipboard = saveClipboardContents(pasteboard)
+
+        // Copy text to clipboard
         pasteboard.clearContents()
 
         let success = pasteboard.setString(text, forType: .string)
@@ -55,6 +59,12 @@ final class PasteService: PasteServiceProtocol {
 
         // Simulate Cmd+V keypress using CGEvent
         try await simulateCmdV()
+
+        // Wait for paste operation to complete in the target application
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // Restore previous clipboard contents
+        restoreClipboardContents(pasteboard, saved: savedClipboard)
 
         Logger.shared.info("Paste operation completed successfully")
     }
@@ -91,5 +101,44 @@ final class PasteService: PasteServiceProtocol {
         keyUpEvent.post(tap: .cghidEventTap)
 
         Logger.shared.debug("Simulated Cmd+V keypress")
+    }
+
+    /// Saves all current clipboard contents with their types
+    private func saveClipboardContents(_ pasteboard: NSPasteboard) -> [(type: NSPasteboard.PasteboardType, data: Data)] {
+        var savedItems: [(type: NSPasteboard.PasteboardType, data: Data)] = []
+
+        // Get all available types in the current pasteboard
+        guard let types = pasteboard.types else {
+            Logger.shared.debug("No clipboard types to save")
+            return savedItems
+        }
+
+        // Save data for each type
+        for type in types {
+            if let data = pasteboard.data(forType: type) {
+                savedItems.append((type: type, data: data))
+                Logger.shared.debug("Saved clipboard data for type: \(type.rawValue)")
+            }
+        }
+
+        Logger.shared.debug("Saved \(savedItems.count) clipboard item(s)")
+        return savedItems
+    }
+
+    /// Restores previously saved clipboard contents
+    private func restoreClipboardContents(_ pasteboard: NSPasteboard, saved: [(type: NSPasteboard.PasteboardType, data: Data)]) {
+        guard !saved.isEmpty else {
+            Logger.shared.debug("No clipboard contents to restore")
+            return
+        }
+
+        pasteboard.clearContents()
+
+        // Restore all saved items
+        for item in saved {
+            pasteboard.setData(item.data, forType: item.type)
+        }
+
+        Logger.shared.debug("Restored \(saved.count) clipboard item(s)")
     }
 }


### PR DESCRIPTION
Modified PasteService to save and restore the system clipboard around paste operations. This prevents the app from permanently overwriting the user's clipboard with dictated text.

Changes:
- Save all clipboard contents (text, images, files, etc.) before paste
- Restore original clipboard after 100ms delay for paste completion
- Added saveClipboardContents() helper to capture all pasteboard types
- Added restoreClipboardContents() helper to restore saved data
- Enhanced logging for clipboard operations

Fixes UX issue where users lose their clipboard contents after dictation.